### PR TITLE
Support RPC in service bindings

### DIFF
--- a/examples/worker/worker-a/index.ts
+++ b/examples/worker/worker-a/index.ts
@@ -1,13 +1,12 @@
 export default {
 	async fetch(request, env, ctx) {
 		const url = new URL(request.url);
-		const response = await env.WORKER_B.fetch(request);
-		const workerBJson = (await response.json()) as any;
+		const result = await env.WORKER_B.add(4, 5);
 
 		return Response.json({
 			name: 'Worker A',
-			worker_b_message: workerBJson.message,
 			pathname: url.pathname,
+			worker_b_rpc_result: result,
 		});
 	},
 } satisfies ExportedHandler<Env>;

--- a/examples/worker/worker-b/index.ts
+++ b/examples/worker/worker-b/index.ts
@@ -1,13 +1,10 @@
-export default {
-	async fetch(request, env, ctx) {
-		const url = new URL(request.url);
-		const count = (await env.MY_KV.get('KEY')) ?? '0';
-		await env.MY_KV.put('KEY', `${Number(count) + 1}`);
+import { WorkerEntrypoint } from 'cloudflare:workers';
 
-		return Response.json({
-			name: 'Worker B',
-			message: `The count is ${count}`,
-			pathname: url.pathname,
-		});
-	},
-} satisfies ExportedHandler<Env>;
+export default class extends WorkerEntrypoint<Env> {
+	override fetch(request: Request) {
+		return Response.json({ name: 'Worker B' });
+	}
+	add(a: number, b: number) {
+		return a + b;
+	}
+}

--- a/packages/vite-plugin-cloudflare/src/runner/worker.ts
+++ b/packages/vite-plugin-cloudflare/src/runner/worker.ts
@@ -69,41 +69,58 @@ function createModuleRunner(env: RunnerEnv, webSocket: WebSocket) {
 let moduleRunner: ModuleRunner;
 let entrypoint: string;
 
-export default {
-	async fetch(request, env, ctx) {
-		const url = new URL(request.url);
+import { WorkerEntrypoint } from 'cloudflare:workers';
 
-		if (url.pathname === INIT_PATH) {
-			if (moduleRunner) {
-				throw new Error('Runner already initialized');
-			}
+class RunnerEntrypoint extends WorkerEntrypoint<RunnerEnv> {
+	constructor(ctx: ExecutionContext, env: RunnerEnv) {
+		super(ctx, env);
 
-			const main = request.headers.get('x-vite-main');
+		return new Proxy(this, {
+			get(target, prop) {
+				if (prop === 'fetch') {
+					return async (request: Request) => {
+						const url = new URL(request.url);
 
-			if (!main) {
-				throw new Error('Missing x-vite-main header');
-			}
+						if (url.pathname === INIT_PATH) {
+							return target.#init.apply(target, [request]);
+						}
 
-			entrypoint = main;
+						return target.#fetch.apply(target, [request]);
+					};
+				} else {
+					return (...args: unknown[]) => {
+						return target.#rpc.apply(target, [prop, args]);
+					};
+				}
+			},
+		});
+	}
 
-			const { 0: client, 1: server } = new WebSocketPair();
-
-			server.accept();
-
-			moduleRunner = createModuleRunner(env, server);
-
-			return new Response(null, { status: 101, webSocket: client });
+	#init(request: Request) {
+		if (moduleRunner) {
+			throw new Error('Runner already initialized');
 		}
 
+		const main = request.headers.get('x-vite-main');
+
+		if (!main) {
+			throw new Error('Missing x-vite-main header');
+		}
+
+		entrypoint = main;
+
+		const { 0: client, 1: server } = new WebSocketPair();
+
+		server.accept();
+
+		moduleRunner = createModuleRunner(this.env, server);
+
+		return new Response(null, { status: 101, webSocket: client });
+	}
+
+	async #fetch(request: Request) {
 		if (!moduleRunner || !entrypoint) {
 			throw new Error('Runner not initialized');
-		}
-
-		const module = await moduleRunner.import(entrypoint);
-		const handler = module.default as ExportedHandler;
-
-		if (!handler.fetch) {
-			throw new Error('Missing fetch handler');
 		}
 
 		const {
@@ -111,8 +128,55 @@ export default {
 			__VITE_FETCH_MODULE__,
 			__VITE_UNSAFE_EVAL__,
 			...filteredEnv
-		} = env;
+		} = this.env;
 
-		return handler.fetch(request, filteredEnv, ctx);
-	},
-} satisfies ExportedHandler<RunnerEnv>;
+		const module = await moduleRunner.import(entrypoint);
+		const handler = module.default;
+
+		if (typeof handler === 'function') {
+			const workerEntrypoint = new handler(this.ctx, filteredEnv);
+
+			if (!workerEntrypoint.fetch) {
+				throw new Error('Missing fetch handler');
+			}
+
+			return workerEntrypoint.fetch(request);
+		}
+
+		if (!handler.fetch) {
+			throw new Error('Missing fetch handler');
+		}
+
+		return handler.fetch(request, filteredEnv, this.ctx);
+	}
+
+	async #rpc(prop: string | symbol, args: unknown[]) {
+		if (!moduleRunner || !entrypoint) {
+			throw new Error('Runner not initialized');
+		}
+
+		const {
+			__VITE_ROOT__,
+			__VITE_FETCH_MODULE__,
+			__VITE_UNSAFE_EVAL__,
+			...filteredEnv
+		} = this.env;
+
+		const module = await moduleRunner.import(entrypoint);
+		const WorkerEntrypoint = module.default;
+
+		if (typeof WorkerEntrypoint !== 'function') {
+			throw new Error('RPC error 1');
+		}
+
+		const workerEntrypoint = new WorkerEntrypoint(this.ctx, filteredEnv);
+
+		if (!workerEntrypoint[prop]) {
+			throw new Error('RPC error 2');
+		}
+
+		return workerEntrypoint[prop](...args);
+	}
+}
+
+export default RunnerEntrypoint;

--- a/packages/vite-plugin-cloudflare/tsup.config.ts
+++ b/packages/vite-plugin-cloudflare/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig([
 		format: 'esm',
 		platform: 'neutral',
 		outDir: 'dist/runner',
+		external: ['cloudflare:workers'],
 		noExternal: ['vite/module-runner'],
 		tsconfig: 'tsconfig.runner.json',
 	},


### PR DESCRIPTION
resolves #1, resolves #2

This PR adds support for RPC via service bindings and workers defined as classes. It does this by using a class that extends `WorkerEntrypoint` as the wrapping worker that contains the module runner. The class constructor returns a `Proxy` that wraps the class and intercepts any method calls. These are then forwarded to the user code.