### PR TITLE
Add basic build support

### DIFF
--- a/examples/durable-object/package.json
+++ b/examples/durable-object/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"build": "vite build --app",
 		"dev": "vite dev"
 	},
 	"devDependencies": {

--- a/examples/multi-worker/package.json
+++ b/examples/multi-worker/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"build": "vite build --app",
 		"dev": "vite dev"
 	},
 	"devDependencies": {

--- a/examples/worker/package.json
+++ b/examples/worker/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"build": "vite build --app",
 		"dev": "vite dev"
 	},
 	"devDependencies": {

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -131,8 +131,15 @@ export function createCloudflareEnvironment(
 				createEnvironment(name, config) {
 					return new vite.BuildEnvironment(name, config);
 				},
-				// Use the entrypoint for the 'build' command
-				ssr: options.main,
+				ssr: true,
+				rollupOptions: {
+					input: options.main,
+					external: [
+						'cloudflare:email',
+						'cloudflare:sockets',
+						'cloudflare:workers',
+					],
+				},
 			},
 			webCompatible: true,
 		} satisfies vite.EnvironmentOptions,

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from './cloudflare-environment';
 import { getMiniflareOptions } from './miniflare-options';
 import { normalizePluginConfig } from './plugin-config';
+import { invariant } from './shared';
 import type { CloudflareDevEnvironment } from './cloudflare-environment';
 import type { PluginConfig, WorkerOptions } from './plugin-config';
 
@@ -24,13 +25,16 @@ export function cloudflare<T extends Record<string, WorkerOptions>>(
 				builder: {
 					async buildApp(builder) {
 						const environments = Object.keys(pluginConfig.workers).map(
-							(name) => builder.environments[name],
+							(name) => {
+								const environment = builder.environments[name];
+								invariant(environment, `${name} environment not found`);
+
+								return environment;
+							},
 						);
 
 						await Promise.all(
-							environments.map(
-								(environment) => environment && builder.build(environment),
-							),
+							environments.map((environment) => builder.build(environment)),
 						);
 					},
 				},

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -43,8 +43,8 @@ export function cloudflare<T extends Record<string, WorkerOptions>>(
 		},
 		configEnvironment(name, options) {
 			options.build = {
-				...options.build,
 				outDir: path.join('dist', name),
+				...options.build,
 			};
 		},
 		configResolved(resolvedConfig) {


### PR DESCRIPTION
This PR adds basic build functionality so that we can start exploring the build side of things. By default the out directory is `dist/{workerName}`. This can be overridden for each worker in the config using the `overrides.build.outDir` option (we will probably remove this `overrides` option eventually and choose which options to expose).