### PR TITLE
Improve error handling for Miniflare errors

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -58,24 +58,13 @@ export function cloudflare<T extends Record<string, WorkerOptions>>(
 			const { normalizedPluginConfig, wranglerConfigPaths } =
 				normalizePluginConfig(pluginConfig, viteConfig);
 
-			let error: Error | undefined;
-			let miniflare: Miniflare;
+			let error: unknown;
 
-			try {
-				miniflare = new Miniflare(
-					getMiniflareOptions(
-						normalizedPluginConfig,
-						viteConfig,
-						viteDevServer,
-					),
-				);
+			const miniflare = new Miniflare(
+				getMiniflareOptions(normalizedPluginConfig, viteConfig, viteDevServer),
+			);
 
-				await initRunners(normalizedPluginConfig, miniflare, viteDevServer);
-			} catch (err) {
-				if (err instanceof Error) {
-					error = err;
-				}
-			}
+			await initRunners(normalizedPluginConfig, miniflare, viteDevServer);
 
 			viteDevServer.watcher.on('all', async (_, path) => {
 				if (!wranglerConfigPaths.has(path)) {
@@ -94,14 +83,10 @@ export function cloudflare<T extends Record<string, WorkerOptions>>(
 					await initRunners(normalizedPluginConfig, miniflare, viteDevServer);
 
 					error = undefined;
-
 					viteDevServer.environments.client.hot.send({ type: 'full-reload' });
 				} catch (err) {
-					if (err instanceof Error) {
-						error = err;
-
-						viteDevServer.environments.client.hot.send({ type: 'full-reload' });
-					}
+					error = err;
+					viteDevServer.environments.client.hot.send({ type: 'full-reload' });
 				}
 			});
 


### PR DESCRIPTION
This improves the error handling on wrangler config changes so that the Vite dev server is not killed when Miniflare encounters an error. Instead, the error is captured and displayed in the browser overlay on the next request. When the error is resolved, the browser is programatically refreshed.

I tried to implement the same behaviour for initial startup but this won't work as the environments can't be created without Miniflare having successfully initialised.