### PR TITLE
remove unnecessary global setting of `process` in module runner file

### DIFF
--- a/packages/vite-plugin-cloudflare/src/runner/module-runner.ts
+++ b/packages/vite-plugin-cloudflare/src/runner/module-runner.ts
@@ -5,11 +5,6 @@ import type { FetchResult } from 'vite/module-runner';
 
 let moduleRunner: ModuleRunner;
 
-// TODO: node modules using process.env don't find `process` in the global scope for some reason
-//       for now we just create a `process` in the global scope but a proper solution needs to be
-//       implemented (see: https://github.com/flarelabs-net/vite-plugin-cloudflare/issues/22)
-(globalThis as Record<string, unknown>).process = { env: {} };
-
 export async function createModuleRunner(
 	env: WrapperEnv,
 	webSocket: WebSocket,

--- a/tests/integration/module-resolution/wrangler.toml
+++ b/tests/integration/module-resolution/wrangler.toml
@@ -1,1 +1,2 @@
-compatibility_date = "2024-09-09"
+compatibility_date = "2024-10-01"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
fixes #22 

I just noticed that the global process assignment is not actually necessary if we set the appropriate compat date + flag 😕 

I'm not sure how this flew under the radar... maybe back when the compat flag/date wasn't getting properly passed to miniflare and now it is? 🤷

Anyways as far as I can tell this doesn't seem necessary anymore