### PR TITLE
pre-bundling follow ups

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -1,4 +1,5 @@
 import { builtinModules } from 'node:module';
+import * as path from 'node:path';
 import * as vite from 'vite';
 import { INIT_PATH, invariant, UNKNOWN_HOST } from './shared';
 import type { NormalizedPluginConfig, WorkerOptions } from './plugin-config';
@@ -118,7 +119,8 @@ export class CloudflareDevEnvironment extends vite.DevEnvironment {
 	}
 }
 
-export function createCloudflareEnvironment(
+export function createCloudflareEnvironmentOptions(
+	name: string,
 	options: WorkerOptions,
 ): vite.EnvironmentOptions {
 	return vite.mergeConfig(
@@ -158,6 +160,7 @@ export function createCloudflareEnvironment(
 				createEnvironment(name, config) {
 					return new vite.BuildEnvironment(name, config);
 				},
+				outDir: path.join('dist', name),
 				ssr: true,
 				rollupOptions: {
 					// Note: vite starts dev pre-bundling crawling from either optimizeDeps.entries or rollupOptions.input

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -1,9 +1,8 @@
-import * as path from 'node:path';
 import { createMiddleware } from '@hattip/adapter-node';
 import { Miniflare } from 'miniflare';
 import * as vite from 'vite';
 import {
-	createCloudflareEnvironment,
+	createCloudflareEnvironmentOptions,
 	initRunners,
 } from './cloudflare-environment';
 import { getMiniflareOptions } from './miniflare-options';
@@ -38,17 +37,13 @@ export function cloudflare<T extends Record<string, WorkerOptions>>(
 						);
 					},
 				},
+				// Ensure there is an environment for each worker
 				environments: Object.fromEntries(
-					Object.entries(pluginConfig.workers).map(([name, options]) => {
-						return [name, createCloudflareEnvironment(options)];
-					}),
+					Object.entries(pluginConfig.workers).map(([name, workerOptions]) => [
+						name,
+						createCloudflareEnvironmentOptions(name, workerOptions),
+					]),
 				),
-			};
-		},
-		configEnvironment(name, options) {
-			options.build = {
-				outDir: path.join('dist', name),
-				...options.build,
 			};
 		},
 		configResolved(resolvedConfig) {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { Log, LogLevel, Response as MiniflareResponse } from 'miniflare';
 import * as vite from 'vite';
 import { unstable_getMiniflareWorkerOptions } from 'wrangler';
-import { invariant, WORKERD_CUSTOM_IMPORT_PATH } from './shared';
+import { invariant } from './shared';
 import type { CloudflareDevEnvironment } from './cloudflare-environment';
 import type { NormalizedPluginConfig } from './plugin-config';
 import type { MiniflareOptions, SharedOptions, WorkerOptions } from 'miniflare';
@@ -191,7 +191,6 @@ export function getMiniflareOptions(
 
 			return {
 				...workerOptions,
-				unsafeUseModuleFallbackService: true,
 				modules: [
 					{
 						type: 'ESModule',
@@ -204,12 +203,6 @@ export function getMiniflareOptions(
 						contents: fs.readFileSync(
 							fileURLToPath(new URL(RUNNER_PATH, import.meta.url)),
 						),
-					},
-					{
-						// Declared as a CommonJS module so that `require` is made available and we are able to handle cjs imports
-						type: 'CommonJS',
-						path: path.join(miniflareModulesRoot, WORKERD_CUSTOM_IMPORT_PATH),
-						contents: 'module.exports = path => import(path)',
 					},
 				],
 				serviceBindings: {

--- a/packages/vite-plugin-cloudflare/src/shared.ts
+++ b/packages/vite-plugin-cloudflare/src/shared.ts
@@ -1,6 +1,5 @@
 export const UNKNOWN_HOST = 'http://localhost';
 export const INIT_PATH = '/__vite_plugin_cloudflare_init__';
-export const WORKERD_CUSTOM_IMPORT_PATH = '__WORKERD_CUSTOM_IMPORT_PATH__';
 
 export function invariant(
 	condition: unknown,


### PR DESCRIPTION
Now that we are prebundling, and can turn on npdejs_compat, some of the hacks from before are no longer needed.

- remove the fake process global
- remove the workerd custom import module
- remove the unsafeUseModuleFallbackService property
- consolidate environment options creation
- move vite override to the workspace catalog