### PR TITLE
make sure that the root `check:types` script includes the playground

### DIFF
--- a/playground/durable-objects/package.json
+++ b/playground/durable-objects/package.json
@@ -4,12 +4,14 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
+		"check:types": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"
 	}

--- a/playground/external-durable-objects/package.json
+++ b/playground/external-durable-objects/package.json
@@ -4,12 +4,14 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
+		"check:types": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"
 	}

--- a/playground/module-resolution/package.json
+++ b/playground/module-resolution/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
+		"check:types": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {

--- a/playground/multi-worker/package.json
+++ b/playground/multi-worker/package.json
@@ -4,12 +4,14 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
+		"check:types": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"
 	}

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,7 +3,11 @@
 	"version": "1.0.0",
 	"private": true,
 	"type": "module",
+	"scripts": {
+		"check:types": "tsc --build"
+	},
 	"devDependencies": {
-		"@vite-plugin-cloudflare/typescript-config": "workspace:*"
+		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default"
 	}
 }

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "@vite-plugin-cloudflare/typescript-config/base.json",
+	"include": ["__test-utils__/**/*.ts"]
+}

--- a/playground/vitest-setup.ts
+++ b/playground/vitest-setup.ts
@@ -99,6 +99,7 @@ beforeAll(async (s) => {
 	browser = await chromium.connect(wsEndpoint);
 	page = await browser.newPage();
 
+	// @ts-ignore
 	const globalConsole = global.console;
 	const warn = globalConsole.warn;
 	globalConsole.warn = (msg: string, ...args: unknown[]) => {

--- a/playground/vitest-setup.ts
+++ b/playground/vitest-setup.ts
@@ -99,8 +99,7 @@ beforeAll(async (s) => {
 	browser = await chromium.connect(wsEndpoint);
 	page = await browser.newPage();
 
-	// @ts-ignore
-	const globalConsole = global.console;
+	const globalConsole = console;
 	const warn = globalConsole.warn;
 	globalConsole.warn = (msg: string, ...args: unknown[]) => {
 		if (msg.includes('Generated an empty chunk')) return;

--- a/playground/worker/package.json
+++ b/playground/worker/package.json
@@ -4,12 +4,14 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build --app",
+		"check:types": "tsc --build",
 		"dev": "vite dev"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
 
   playground/durable-objects:
     devDependencies:
@@ -99,6 +102,9 @@ importers:
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
       vite:
         specifier: catalog:default
         version: 6.0.0-beta.4(@types/node@22.5.5)
@@ -117,6 +123,9 @@ importers:
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
       vite:
         specifier: catalog:default
         version: 6.0.0-beta.4(@types/node@22.5.5)
@@ -177,6 +186,9 @@ importers:
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
       vite:
         specifier: catalog:default
         version: 6.0.0-beta.4(@types/node@22.5.5)
@@ -195,6 +207,9 @@ importers:
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
       vite:
         specifier: catalog:default
         version: 6.0.0-beta.4(@types/node@22.5.5)


### PR DESCRIPTION
Currently if you run `check:types` at the root of the repo the playground and its apps aren't actually getting checked, I am addressing that here

Sorry I missed this in my refactoring PR 😓

(I've been just manually checking the types via Vscode)