### PR TITLE
remove node builtin modules from module-resolution packages

### DIFF
--- a/playground/module-resolution/packages/imports/node-builtins.d.ts
+++ b/playground/module-resolution/packages/imports/node-builtins.d.ts
@@ -1,2 +1,0 @@
-export const bufferConstants: typeof import('buffer').constants;
-export const nodeBufferConstants: typeof import('node:buffer').constants;

--- a/playground/module-resolution/packages/imports/node-builtins.js
+++ b/playground/module-resolution/packages/imports/node-builtins.js
@@ -1,2 +1,0 @@
-export { constants as bufferConstants } from 'buffer';
-export { constants as nodeBufferConstants } from 'node:buffer';

--- a/playground/module-resolution/packages/imports/package.json
+++ b/playground/module-resolution/packages/imports/package.json
@@ -7,10 +7,6 @@
 		"./cloudflare-builtins": {
 			"default": "./cloudflare-builtins.js",
 			"types": "./cloudflare-builtins.d.ts"
-		},
-		"./node-builtins": {
-			"default": "./node-builtins.js",
-			"types": "./node-builtins.d.ts"
 		}
 	}
 }

--- a/playground/module-resolution/packages/requires/node-builtins.d.ts
+++ b/playground/module-resolution/packages/requires/node-builtins.d.ts
@@ -1,2 +1,0 @@
-export const bufferConstants: typeof import('buffer').constants;
-export const nodeBufferConstants: typeof import('node:buffer').constants;

--- a/playground/module-resolution/packages/requires/node-builtins.js
+++ b/playground/module-resolution/packages/requires/node-builtins.js
@@ -1,2 +1,0 @@
-export const bufferConstants = require('buffer').constants;
-export const nodeBufferConstants = require('node:buffer').constants;

--- a/playground/module-resolution/packages/requires/package.json
+++ b/playground/module-resolution/packages/requires/package.json
@@ -11,10 +11,6 @@
 			"default": "./no-ext.js",
 			"types": "./no-ext.d.ts"
 		},
-		"./node-builtins": {
-			"default": "./node-builtins.js",
-			"types": "./node-builtins.d.ts"
-		},
 		"./json": {
 			"default": "./json.js",
 			"types": "./json.d.ts"


### PR DESCRIPTION
In #49 we've removed the [`/node-builtins` route](https://github.com/flarelabs-net/vite-plugin-cloudflare/pull/49/files#diff-0a0a6d7969c4c8fd16658b1e9eebefb65d799401b5169b99ab71a5d882fcd66dL4) (alongside its [tests](https://github.com/flarelabs-net/vite-plugin-cloudflare/pull/49/files#diff-169f43f0123c0e0b96fdf683df9f61bb2f8d19852fd590abb2629fa55f87b608L34-L45)) we've however missed to remove the node builtins related files from the packages defined in the `module-resolution` app, this PR is cleaning those up (since they are no longer needed/used)