### PR TITLE
make module resolution app index route more friendly/convenient

### DIFF
--- a/playground/module-resolution/src/index.ts
+++ b/playground/module-resolution/src/index.ts
@@ -17,13 +17,29 @@ export default {
 			return test();
 		}
 
-		return new Response(
-			`path not found: '${path}' (the available paths are: ${Object.keys(
-				modules,
-			)
-				.map((path) => path.replace(/^\.\//, '/').replace(/\.ts$/, ''))
-				.join(', ')})`,
-			{ status: 404 },
-		);
+		const html = `<!DOCTYPE html>
+            <body>
+              <h1>Module Resolution App</h1>
+              <p>
+                This app is an example/test for dependencies module resolution being performed in the Cloudflare environment (inside the workerd runtime)
+              </p>
+              <hr />
+              <h2>Available Routes</h2>
+              <ul>
+              ${[...Object.keys(modules), '/@alias/test']
+								.map((path) => path.replace(/^\.\//, '/').replace(/\.ts$/, ''))
+								.map(
+									(route) =>
+										`                <li><a href="${route}">${route}</a></li>`,
+								)
+								.join('\n')}
+              </ul>
+            </body>`;
+
+		return new Response(html, {
+			headers: {
+				'content-type': 'text/html;charset=UTF-8',
+			},
+		});
 	},
 } satisfies ExportedHandler;


### PR DESCRIPTION
This is very minor, but I figured the main/index route for the module resolution app could be more friendly / convenient and allow you to easily navigate through the various routes (without needing to copy-paste them)

| Before | After |
|--------|--------|
| ![Screenshot 2024-12-06 at 20 06 12](https://github.com/user-attachments/assets/300af776-5e15-4a24-8a9e-802d3d5b2338) | ![Screenshot 2024-12-06 at 20 06 41](https://github.com/user-attachments/assets/99751868-1f99-413b-902f-d90e8dacf78c) |