### PR TITLE
Update dependencies

### DIFF
--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -35,8 +35,8 @@
 		"watch": "tsup --watch"
 	},
 	"dependencies": {
-		"@hattip/adapter-node": "^0.0.48",
-		"miniflare": "beta"
+		"@hattip/adapter-node": "^0.0.49",
+		"miniflare": "^3.20241205.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-shared": "^0.7.0",

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -298,7 +298,7 @@ export function getDevMiniflareOptions(
 											type: 'builtin',
 										} satisfies vite.FetchResult;
 
-										return new MiniflareResponse(JSON.stringify({ r: result }));
+										return new MiniflareResponse(JSON.stringify({ result }));
 									}
 
 									// Sometimes Vite fails to resolve built-ins and converts them to "url-friendly" ids
@@ -309,7 +309,7 @@ export function getDevMiniflareOptions(
 											type: 'builtin',
 										} satisfies vite.FetchResult;
 
-										return new MiniflareResponse(JSON.stringify({ r: result }));
+										return new MiniflareResponse(JSON.stringify({ result }));
 									}
 
 									const devEnvironment = viteDevServer.environments[

--- a/packages/vite-plugin-cloudflare/src/runner-worker/module-runner.ts
+++ b/packages/vite-plugin-cloudflare/src/runner-worker/module-runner.ts
@@ -43,7 +43,7 @@ export async function createModuleRunner(
 
 					const result = await response.json();
 
-					return result as { r: any } | { e: any };
+					return result as { result: any } | { error: any };
 				},
 			},
 			hmr: true,

--- a/playground/react-spa/package.json
+++ b/playground/react-spa/package.json
@@ -9,16 +9,16 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"react": "18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
-		"@types/react": "^18.3.11",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.0.0",
+		"@types/react-dom": "^19.0.0",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
-		"@vitejs/plugin-react": "^4.3.3",
+		"@vitejs/plugin-react": "^4.3.4",
 		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"

--- a/playground/spa-with-api/package.json
+++ b/playground/spa-with-api/package.json
@@ -9,16 +9,16 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"react": "18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:default",
 		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
-		"@types/react": "^18.3.11",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.0.0",
+		"@types/react-dom": "^19.0.0",
 		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
-		"@vitejs/plugin-react": "^4.3.3",
+		"@vitejs/plugin-react": "^4.3.4",
 		"typescript": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@cloudflare/workers-types':
-      specifier: ^4.20241112.0
-      version: 4.20241112.0
+      specifier: ^4.20241205.0
+      version: 4.20241205.0
     '@types/node':
-      specifier: ^22.8.7
-      version: 22.9.0
+      specifier: ^22.10.1
+      version: 22.10.1
     typescript:
-      specifier: ^5.6.2
-      version: 5.6.2
+      specifier: ^5.7.2
+      version: 5.7.2
     unenv:
-      specifier: npm:unenv-nightly@2.0.0-20241024-111401-d4156ac
-      version: 2.0.0-20241024-111401-d4156ac
+      specifier: npm:unenv-nightly@2.0.0-20241204-140205-a5d5190
+      version: 2.0.0-20241204-140205-a5d5190
     vite:
-      specifier: 6.0.0-beta.10
-      version: 6.0.0-beta.10
+      specifier: 6.0.3
+      version: 6.0.3
     wrangler:
-      specifier: beta
-      version: 0.0.0-b9d4d5adb
+      specifier: ^3.93.0
+      version: 3.93.0
 
 importers:
 
@@ -53,34 +53,34 @@ importers:
         version: 2.5.3(prettier@3.3.3)
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       vitest:
         specifier: ^2.1.3
-        version: 2.1.3(@types/node@22.9.0)
+        version: 2.1.3(@types/node@22.10.1)
 
   packages/typescript-config: {}
 
   packages/vite-plugin-cloudflare:
     dependencies:
       '@hattip/adapter-node':
-        specifier: ^0.0.48
-        version: 0.0.48
+        specifier: ^0.0.49
+        version: 0.0.49
       miniflare:
-        specifier: beta
-        version: 0.0.0-b9d4d5adb
+        specifier: ^3.20241205.0
+        version: 3.20241205.0
     devDependencies:
       '@cloudflare/workers-shared':
         specifier: ^0.7.0
         version: 0.7.0
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@types/node':
         specifier: catalog:default
-        version: 22.9.0
+        version: 22.10.1
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -89,19 +89,19 @@ importers:
         version: 0.30.12
       tsup:
         specifier: ^8.3.0
-        version: 8.3.0(postcss@8.4.49)(typescript@5.6.2)
+        version: 8.3.0(postcss@8.4.49)(typescript@5.7.2)
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       unenv:
         specifier: catalog:default
-        version: unenv-nightly@2.0.0-20241024-111401-d4156ac
+        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground:
     devDependencies:
@@ -110,13 +110,13 @@ importers:
         version: link:../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
 
   playground/durable-objects:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -125,19 +125,19 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/external-durable-objects:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -146,19 +146,19 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/hot-channel:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -167,13 +167,13 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/module-resolution:
     devDependencies:
@@ -185,13 +185,13 @@ importers:
         version: '@playground/module-resolution-requires@file:playground/module-resolution/packages/requires'
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
       '@remix-run/cloudflare':
         specifier: 2.12.0
-        version: 2.12.0(@cloudflare/workers-types@4.20241112.0)(typescript@5.6.2)
+        version: 2.12.0(@cloudflare/workers-types@4.20241205.0)(typescript@5.7.2)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.12
@@ -209,19 +209,19 @@ importers:
         version: 6.2.1
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/multi-worker:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -230,25 +230,25 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/node-compat:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
       '@types/node':
         specifier: catalog:default
-        version: 22.9.0
+        version: 22.10.1
       '@types/pg':
         specifier: ^8.11.2
         version: 8.11.10
@@ -266,96 +266,96 @@ importers:
         version: 1.1.1
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       unenv:
         specifier: catalog:default
-        version: unenv-nightly@2.0.0-20241024-111401-d4156ac
+        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/react-spa:
     dependencies:
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
       '@types/react':
-        specifier: ^18.3.11
-        version: 18.3.12
+        specifier: ^19.0.0
+        version: 19.0.1
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.1
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@6.0.0-beta.10(@types/node@22.9.0))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.0.3(@types/node@22.10.1))
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/spa-with-api:
     dependencies:
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
       '@types/react':
-        specifier: ^18.3.11
-        version: 18.3.12
+        specifier: ^19.0.0
+        version: 19.0.1
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.1
       '@vite-plugin-cloudflare/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
       '@vitejs/plugin-react':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@6.0.0-beta.10(@types/node@22.9.0))
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.0.3(@types/node@22.10.1))
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/static-mpa:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -364,19 +364,19 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
   playground/worker:
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:default
-        version: 4.20241112.0
+        version: 4.20241205.0
       '@flarelabs-net/vite-plugin-cloudflare':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-cloudflare
@@ -385,13 +385,13 @@ importers:
         version: link:../../packages/typescript-config
       typescript:
         specifier: catalog:default
-        version: 5.6.2
+        version: 5.7.2
       vite:
         specifier: catalog:default
-        version: 6.0.0-beta.10(@types/node@22.9.0)
+        version: 6.0.3(@types/node@22.10.1)
       wrangler:
         specifier: catalog:default
-        version: 0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0)
+        version: 3.93.0(@cloudflare/workers-types@4.20241205.0)
 
 packages:
 
@@ -403,28 +403,58 @@ packages:
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.25.8':
     resolution: {integrity: sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.26.3':
+    resolution: {integrity: sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.25.8':
     resolution: {integrity: sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@7.26.0':
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.25.7':
     resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.26.3':
+    resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.25.7':
     resolution: {integrity: sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-compilation-targets@7.25.9':
+    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.25.7':
     resolution: {integrity: sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.25.7':
     resolution: {integrity: sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -441,16 +471,32 @@ packages:
     resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.7':
     resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.7':
     resolution: {integrity: sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helpers@7.25.7':
     resolution: {integrity: sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.26.0':
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.25.7':
@@ -459,6 +505,11 @@ packages:
 
   '@babel/parser@7.25.8':
     resolution: {integrity: sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.26.3':
+    resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -478,12 +529,24 @@ packages:
     resolution: {integrity: sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.25.7':
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.26.4':
+    resolution: {integrity: sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.25.8':
     resolution: {integrity: sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.3':
+    resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
   '@cloudflare/kv-asset-handler@0.1.3':
@@ -523,16 +586,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-shared@0.0.0-b9d4d5adb':
-    resolution: {integrity: sha512-JptHSDcezTP3fYK4JRSWIkGTCe80RWPdzxXS0nY1VGHfMRf7GgGlxYVjumrGvGcL8Lv9iElqx5EZsYV9GAJZoA==}
+  '@cloudflare/workers-shared@0.10.0':
+    resolution: {integrity: sha512-j3EwZBc9ctavmFVOQT1gqztRO/Plx4ZR0LMEEOif+5YoCcuD1P7/NEjlODPMc5a1w+8+7A/H+Ci8Ihd55+x0Zw==}
     engines: {node: '>=16.7.0'}
 
   '@cloudflare/workers-shared@0.7.0':
     resolution: {integrity: sha512-LLQRTqx7lKC7o2eCYMpyc5FXV8d0pUX6r3A+agzhqS9aoR5A6zCPefwQGcvbKx83ozX22ATZcemwxQXn12UofQ==}
     engines: {node: '>=16.7.0'}
 
-  '@cloudflare/workers-types@4.20241112.0':
-    resolution: {integrity: sha512-Q4p9bAWZrX14bSCKY9to19xl0KMU7nsO5sJ2cTVspHoypsjPUMeQCsjHjmsO2C4Myo8/LPeDvmqFmkyNAPPYZw==}
+  '@cloudflare/workers-types@4.20241205.0':
+    resolution: {integrity: sha512-pj1VKRHT/ScQbHOIMFODZaNAlJHQHdBSZXNIdr9ebJzwBff9Qz8VdqhbhggV7f+aUEh8WSbrsPIo4a+WtgjUvw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1110,20 +1173,20 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@hattip/adapter-node@0.0.48':
-    resolution: {integrity: sha512-4Oblq0NOOmjjbI6Di9Gb9dEtjaLEIfWnT5aDZIODnvT8/EjRTTylHzJPCXTXoNyFg73ehjlNWAgs8ZPbH9wLcQ==}
+  '@hattip/adapter-node@0.0.49':
+    resolution: {integrity: sha512-BE+Y8Q4U0YcH34FZUYU4DssGKOaZLbNL0zK57Z41UZp0m9kS79ZIolBmjjpPhTVpIlRY3Rs+uhXbVXKk7mUcJA==}
 
-  '@hattip/core@0.0.48':
-    resolution: {integrity: sha512-rx28E2Ofl2GpJ73Uw011d1kM3kLyuFTijcBZjRWZn6cZ6qmFI194BZLtsvvO3ocBgyUUVv4JPC9PdH5FGA/ZoA==}
+  '@hattip/core@0.0.49':
+    resolution: {integrity: sha512-3/ZJtC17cv8m6Sph8+nw4exUp9yhEf2Shi7HK6AHSUSBtaaQXZ9rJBVxTfZj3PGNOR/P49UBXOym/52WYKFTJQ==}
 
-  '@hattip/headers@0.0.48':
-    resolution: {integrity: sha512-mvw5L4VFaKS3ug/QiTq+MJovzhH2kr4Pso1LdH1UnY4sjkcrAtFoe7g2AZRYfodPem4NQQCTI35CWKT+/KbvcQ==}
+  '@hattip/headers@0.0.49':
+    resolution: {integrity: sha512-rrB2lEhTf0+MNVt5WdW184Ky706F1Ze9Aazn/R8c+/FMUYF9yjem2CgXp49csPt3dALsecrnAUOHFiV0LrrHXA==}
 
-  '@hattip/polyfills@0.0.48':
-    resolution: {integrity: sha512-r9Q5cGpAyN/2HL3UI1z1prrIok3kopnszgXFIP1Ns4lMsukc9bYosrDVH2ZKIJ4Zowzi6kzH0/kE6VsUgfuESQ==}
+  '@hattip/polyfills@0.0.49':
+    resolution: {integrity: sha512-5g7W5s6Gq+HDxwULGFQ861yAnEx3yd9V8GDwS96HBZ1nM1u93vN+KTuwXvNsV7Z3FJmCrD/pgU8WakvchclYuA==}
 
-  '@hattip/walk@0.0.48':
-    resolution: {integrity: sha512-S97D+m2khXM4x8p7laLERE+rZAhJXc8joZGxLUSU5WEtBD1Br5BlFL9DPBYKtSX7joLE104TpIjjquJjPZtpQw==}
+  '@hattip/walk@0.0.49':
+    resolution: {integrity: sha512-AgJgKLooZyQnzMfoFg5Mo/aHM+HGBC9ExpXIjNqGimYTRgNbL/K7X5EM1kR2JY90BNKk9lo6Usq1T/nWFdT7TQ==}
     hasBin: true
 
   '@ianvs/prettier-plugin-sort-imports@4.3.1':
@@ -1456,8 +1519,8 @@ packages:
   '@types/node-forge@1.3.11':
     resolution: {integrity: sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==}
 
-  '@types/node@22.9.0':
-    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+  '@types/node@22.10.1':
+    resolution: {integrity: sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==}
 
   '@types/pg@8.11.10':
     resolution: {integrity: sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==}
@@ -1465,17 +1528,20 @@ packages:
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
 
-  '@types/react-dom@18.3.1':
-    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+  '@types/react-dom@19.0.1':
+    resolution: {integrity: sha512-hljHij7MpWPKF6u5vojuyfV0YA4YURsQG7KT6SzV0Zs2BXAtgdTxG6A229Ub/xiWV4w/7JL8fi6aAyjshH4meA==}
 
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
-  '@vitejs/plugin-react@4.3.3':
-    resolution: {integrity: sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==}
+  '@types/react@19.0.1':
+    resolution: {integrity: sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==}
+
+  '@vitejs/plugin-react@4.3.4':
+    resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitest/expect@2.1.3':
     resolution: {integrity: sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==}
@@ -1510,12 +1576,12 @@ packages:
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
-  '@whatwg-node/fetch@0.9.21':
-    resolution: {integrity: sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==}
+  '@whatwg-node/fetch@0.9.23':
+    resolution: {integrity: sha512-7xlqWel9JsmxahJnYVUj/LLxWcnA93DR4c9xlw3U814jWTiYalryiH1qToik1hOxweKKRLi4haXHM5ycRksPBA==}
     engines: {node: '>=18.0.0'}
 
-  '@whatwg-node/node-fetch@0.5.26':
-    resolution: {integrity: sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g==}
+  '@whatwg-node/node-fetch@0.6.0':
+    resolution: {integrity: sha512-tcZAhrpx6oVlkEsRngeTEEE7I5/QdLjeEz4IlekabGaESP7+Dkm/6a9KcF1KdCBB7mO9PXtBkwCuTCt8+UPg8Q==}
     engines: {node: '>=18.0.0'}
 
   acorn-walk@8.3.4:
@@ -2020,8 +2086,8 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  miniflare@0.0.0-b9d4d5adb:
-    resolution: {integrity: sha512-JWDmLvnXyZTMwybMz8lq8+FPf1dAQCknDAPHrKgNiIT8T/sHRt3EoJrTne7NGL2ykYuxgXayK3d8l+qiycklPA==}
+  miniflare@3.20241205.0:
+    resolution: {integrity: sha512-Z0cTtIf6ZrcAJ3SrOI9EUM3s4dkGhNeU6Ubl8sroYhsPVD+rtz3m5+p6McHFWCkcMff1o60X5XEKVTmkz0gbpA==}
     engines: {node: '>=16.13'}
     hasBin: true
 
@@ -2296,10 +2362,10 @@ packages:
     resolution: {integrity: sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==}
     engines: {node: '>=18'}
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+  react-dom@19.0.0:
+    resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.0.0
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -2307,6 +2373,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.0.0:
+    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
@@ -2352,8 +2422,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
@@ -2584,16 +2654,16 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -2602,9 +2672,6 @@ packages:
   undici@6.21.0:
     resolution: {integrity: sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==}
     engines: {node: '>=18.17'}
-
-  unenv-nightly@2.0.0-20241024-111401-d4156ac:
-    resolution: {integrity: sha512-xJO1hfY+Te+/XnfCYrCbFbRcgu6XEODND1s5wnVbaBCkuQX7JXF7fHEXPrukFE2j8EOH848P8QN19VO47XN8hw==}
 
   unenv-nightly@2.0.0-20241204-140205-a5d5190:
     resolution: {integrity: sha512-jpmAytLeiiW01pl5bhVn9wYJ4vtiLdhGe10oXlJBuQEX8mxjxO8BlEXGHU4vr4yEikjFP1wsomTHt/CLU8kUwg==}
@@ -2665,12 +2732,12 @@ packages:
       terser:
         optional: true
 
-  vite@6.0.0-beta.10:
-    resolution: {integrity: sha512-I+XjYmS0KAx8kxYTFidFZRkDG1h7bKfharrtjFWkKYZxGaUSKMqZZdsJ9Wsh0myRlzzWdRgty9jGC51bAl8BYA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.0.3:
+    resolution: {integrity: sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
       jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
@@ -2757,8 +2824,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@0.0.0-b9d4d5adb:
-    resolution: {integrity: sha512-KMJXOo+XKxMwUVeebJLfkx//yNZcNkE1DLT3L56c/bs/HdcZmXuIA3Y7uOcBt+8i42oyyKcpvLPrClCbUMnZ5w==}
+  wrangler@3.93.0:
+    resolution: {integrity: sha512-+wfxjOrtm6YgDS+NdJkB6aiBIS3ED97mNRQmfrEShRJW4pVo4sWY6oQ1FsGT+j4tGHplrTbWCE6U5yTgjNW/lw==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
@@ -2822,7 +2889,15 @@ snapshots:
       '@babel/highlight': 7.25.7
       picocolors: 1.1.0
 
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.25.8': {}
+
+  '@babel/compat-data@7.26.3': {}
 
   '@babel/core@7.25.8':
     dependencies:
@@ -2844,9 +2919,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@7.26.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.3
+      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.3
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+      convert-source-map: 2.0.0
+      debug: 4.3.7
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.25.7':
     dependencies:
       '@babel/types': 7.25.8
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
+  '@babel/generator@7.26.3':
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
@@ -2859,10 +2962,25 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@7.25.9':
+    dependencies:
+      '@babel/compat-data': 7.26.3
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-module-imports@7.25.7':
     dependencies:
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2873,6 +2991,15 @@ snapshots:
       '@babel/helper-simple-access': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       '@babel/traverse': 7.25.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2887,14 +3014,25 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.7': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.25.7': {}
 
+  '@babel/helper-validator-identifier@7.25.9': {}
+
   '@babel/helper-validator-option@7.25.7': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helpers@7.25.7':
     dependencies:
       '@babel/template': 7.25.7
       '@babel/types': 7.25.8
+
+  '@babel/helpers@7.26.0':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.3
 
   '@babel/highlight@7.25.7':
     dependencies:
@@ -2907,14 +3045,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.8
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.25.8)':
+  '@babel/parser@7.26.3':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/types': 7.26.3
+
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.25.8)':
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/template@7.25.7':
@@ -2922,6 +3064,12 @@ snapshots:
       '@babel/code-frame': 7.25.7
       '@babel/parser': 7.25.8
       '@babel/types': 7.25.8
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
 
   '@babel/traverse@7.25.7':
     dependencies:
@@ -2935,11 +3083,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.26.4':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.3
+      '@babel/parser': 7.26.3
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.3
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.25.8':
     dependencies:
       '@babel/helper-string-parser': 7.25.7
       '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.26.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@cloudflare/kv-asset-handler@0.1.3':
     dependencies:
@@ -2964,7 +3129,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20241205.0':
     optional: true
 
-  '@cloudflare/workers-shared@0.0.0-b9d4d5adb':
+  '@cloudflare/workers-shared@0.10.0':
     dependencies:
       mime: 3.0.0
       zod: 3.23.8
@@ -2974,7 +3139,7 @@ snapshots:
       mime: 3.0.0
       zod: 3.23.8
 
-  '@cloudflare/workers-types@4.20241112.0': {}
+  '@cloudflare/workers-types@4.20241205.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3271,27 +3436,27 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@hattip/adapter-node@0.0.48':
+  '@hattip/adapter-node@0.0.49':
     dependencies:
-      '@hattip/core': 0.0.48
-      '@hattip/polyfills': 0.0.48
-      '@hattip/walk': 0.0.48
+      '@hattip/core': 0.0.49
+      '@hattip/polyfills': 0.0.49
+      '@hattip/walk': 0.0.49
 
-  '@hattip/core@0.0.48': {}
+  '@hattip/core@0.0.49': {}
 
-  '@hattip/headers@0.0.48':
+  '@hattip/headers@0.0.49':
     dependencies:
-      '@hattip/core': 0.0.48
+      '@hattip/core': 0.0.49
 
-  '@hattip/polyfills@0.0.48':
+  '@hattip/polyfills@0.0.49':
     dependencies:
-      '@hattip/core': 0.0.48
-      '@whatwg-node/fetch': 0.9.21
+      '@hattip/core': 0.0.49
+      '@whatwg-node/fetch': 0.9.23
       node-fetch-native: 1.6.4
 
-  '@hattip/walk@0.0.48':
+  '@hattip/walk@0.0.49':
     dependencies:
-      '@hattip/headers': 0.0.48
+      '@hattip/headers': 0.0.49
       cac: 6.7.14
       mime-types: 2.1.35
 
@@ -3440,17 +3605,17 @@ snapshots:
 
   '@playground/module-resolution-requires@file:playground/module-resolution/packages/requires': {}
 
-  '@remix-run/cloudflare@2.12.0(@cloudflare/workers-types@4.20241112.0)(typescript@5.6.2)':
+  '@remix-run/cloudflare@2.12.0(@cloudflare/workers-types@4.20241205.0)(typescript@5.7.2)':
     dependencies:
       '@cloudflare/kv-asset-handler': 0.1.3
-      '@cloudflare/workers-types': 4.20241112.0
-      '@remix-run/server-runtime': 2.12.0(typescript@5.6.2)
+      '@cloudflare/workers-types': 4.20241205.0
+      '@remix-run/server-runtime': 2.12.0(typescript@5.7.2)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
 
   '@remix-run/router@1.19.2': {}
 
-  '@remix-run/server-runtime@2.12.0(typescript@5.6.2)':
+  '@remix-run/server-runtime@2.12.0(typescript@5.7.2)':
     dependencies:
       '@remix-run/router': 1.19.2
       '@types/cookie': 0.6.0
@@ -3460,7 +3625,7 @@ snapshots:
       source-map: 0.7.4
       turbo-stream: 2.4.0
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.7.2
 
   '@rollup/rollup-android-arm-eabi@4.22.4':
     optional: true
@@ -3587,37 +3752,41 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.9.0
+      '@types/node': 22.10.1
 
-  '@types/node@22.9.0':
+  '@types/node@22.10.1':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.20.0
 
   '@types/pg@8.11.10':
     dependencies:
-      '@types/node': 22.9.0
+      '@types/node': 22.10.1
       pg-protocol: 1.7.0
       pg-types: 4.0.2
 
   '@types/prop-types@15.7.13': {}
 
-  '@types/react-dom@18.3.1':
+  '@types/react-dom@19.0.1':
     dependencies:
-      '@types/react': 18.3.12
+      '@types/react': 19.0.1
 
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
       csstype: 3.1.3
 
-  '@vitejs/plugin-react@4.3.3(vite@6.0.0-beta.10(@types/node@22.9.0))':
+  '@types/react@19.0.1':
     dependencies:
-      '@babel/core': 7.25.8
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.25.8)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.25.8)
+      csstype: 3.1.3
+
+  '@vitejs/plugin-react@4.3.4(vite@6.0.3(@types/node@22.10.1))':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.0-beta.10(@types/node@22.9.0)
+      vite: 6.0.3(@types/node@22.10.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3628,13 +3797,13 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.9.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.10.1))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.12
     optionalDependencies:
-      vite: 5.4.10(@types/node@22.9.0)
+      vite: 5.4.10(@types/node@22.10.1)
 
   '@vitest/pretty-format@2.1.3':
     dependencies:
@@ -3663,12 +3832,12 @@ snapshots:
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
-  '@whatwg-node/fetch@0.9.21':
+  '@whatwg-node/fetch@0.9.23':
     dependencies:
-      '@whatwg-node/node-fetch': 0.5.26
+      '@whatwg-node/node-fetch': 0.6.0
       urlpattern-polyfill: 10.0.0
 
-  '@whatwg-node/node-fetch@0.5.26':
+  '@whatwg-node/node-fetch@0.6.0':
     dependencies:
       '@kamilkisiela/fast-url-parser': 1.1.4
       busboy: 1.6.0
@@ -4181,7 +4350,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  miniflare@0.0.0-b9d4d5adb:
+  miniflare@3.20241205.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
@@ -4424,17 +4593,18 @@ snapshots:
 
   quick-lru@7.0.0: {}
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.0.0(react@19.0.0):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.0.0
+      scheduler: 0.25.0
 
   react-refresh@0.14.2: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.0.0: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -4514,9 +4684,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.25.0: {}
 
   selfsigned@2.4.1:
     dependencies:
@@ -4683,7 +4851,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@8.3.0(postcss@8.4.49)(typescript@5.6.2):
+  tsup@8.3.0(postcss@8.4.49)(typescript@5.7.2):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -4703,7 +4871,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.4.49
-      typescript: 5.6.2
+      typescript: 5.7.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -4716,24 +4884,17 @@ snapshots:
 
   type-detect@4.1.0: {}
 
-  typescript@5.6.2: {}
+  typescript@5.7.2: {}
 
   ufo@1.5.4: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.20.0: {}
 
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
 
   undici@6.21.0: {}
-
-  unenv-nightly@2.0.0-20241024-111401-d4156ac:
-    dependencies:
-      defu: 6.1.4
-      ohash: 1.1.4
-      pathe: 1.1.2
-      ufo: 1.5.4
 
   unenv-nightly@2.0.0-20241204-140205-a5d5190:
     dependencies:
@@ -4756,12 +4917,12 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@2.1.3(@types/node@22.9.0):
+  vite-node@2.1.3(@types/node@22.10.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.10(@types/node@22.9.0)
+      vite: 5.4.10(@types/node@22.10.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4773,28 +4934,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.10(@types/node@22.9.0):
+  vite@5.4.10(@types/node@22.10.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 22.10.1
       fsevents: 2.3.3
 
-  vite@6.0.0-beta.10(@types/node@22.9.0):
+  vite@6.0.3(@types/node@22.10.1):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 22.10.1
       fsevents: 2.3.3
 
-  vitest@2.1.3(@types/node@22.9.0):
+  vitest@2.1.3(@types/node@22.10.1):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.9.0))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.10.1))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -4809,11 +4970,11 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.10(@types/node@22.9.0)
-      vite-node: 2.1.3(@types/node@22.9.0)
+      vite: 5.4.10(@types/node@22.10.1)
+      vite-node: 2.1.3(@types/node@22.10.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.9.0
+      '@types/node': 22.10.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -4857,10 +5018,10 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20241205.0
       '@cloudflare/workerd-windows-64': 1.20241205.0
 
-  wrangler@0.0.0-b9d4d5adb(@cloudflare/workers-types@4.20241112.0):
+  wrangler@3.93.0(@cloudflare/workers-types@4.20241205.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/workers-shared': 0.0.0-b9d4d5adb
+      '@cloudflare/workers-shared': 0.10.0
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
@@ -4868,7 +5029,7 @@ snapshots:
       date-fns: 4.1.0
       esbuild: 0.17.19
       itty-time: 1.0.6
-      miniflare: 0.0.0-b9d4d5adb
+      miniflare: 3.20241205.0
       nanoid: 3.3.7
       path-to-regexp: 6.3.0
       resolve: 1.22.8
@@ -4878,7 +5039,7 @@ snapshots:
       workerd: 1.20241205.0
       xxhash-wasm: 1.0.2
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20241112.0
+      '@cloudflare/workers-types': 4.20241205.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,9 @@ packages:
   - 'playground/*'
 
 catalog:
-  '@cloudflare/workers-types': ^4.20241112.0
-  'typescript': ^5.6.2
-  'vite': '6.0.0-beta.10'
-  'wrangler': 'beta'
-  '@types/node': '^22.8.7'
-  'unenv': 'npm:unenv-nightly@2.0.0-20241024-111401-d4156ac'
+  '@cloudflare/workers-types': '^4.20241205.0'
+  'typescript': '^5.7.2'
+  'vite': '6.0.3'
+  'wrangler': '^3.93.0'
+  '@types/node': '^22.10.1'
+  'unenv': 'npm:unenv-nightly@2.0.0-20241204-140205-a5d5190'


### PR DESCRIPTION
Updates dependencies and gets us back off the beta version of Wrangler and Miniflare.

Note that I'm still pinning to a specific version of Vite even though Vite 6 is stable as the environment API itself is still experimental. We'll need to think about how to approach this when we release.