### PR TITLE
Restart dev server on Worker config changes

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -25,7 +25,7 @@ import type { Unstable_RawConfig } from 'wrangler';
 
 export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 	let resolvedPluginConfig: ResolvedPluginConfig;
-	let miniflare: Miniflare;
+	let miniflare: Miniflare | undefined;
 
 	return {
 		name: 'vite-plugin-cloudflare',
@@ -203,7 +203,10 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 			}
 		},
 		async buildEnd() {
-			await miniflare?.dispose();
+			if (miniflare) {
+				await miniflare?.dispose();
+				miniflare = undefined;
+			}
 		},
 		async configureServer(viteDevServer) {
 			miniflare = new Miniflare(
@@ -231,7 +234,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 			};
 		},
 		configurePreviewServer(vitePreviewServer) {
-			miniflare = new Miniflare(
+			const miniflare = new Miniflare(
 				getPreviewMiniflareOptions(resolvedPluginConfig, vitePreviewServer),
 			);
 

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -198,6 +198,9 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 				source: JSON.stringify(config),
 			});
 		},
+		// hotUpdate(options) {
+		// },
+		// handleHotUpdate(options) {},
 		async configureServer(viteDevServer) {
 			let error: unknown;
 
@@ -207,30 +210,30 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 
 			await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
 
-			viteDevServer.watcher.on('all', async (_, path) => {
-				if (!resolvedPluginConfig.configPaths.has(path)) {
-					return;
-				}
+			// viteDevServer.watcher.on('all', async (_, path) => {
+			// 	if (!resolvedPluginConfig.configPaths.has(path)) {
+			// 		return;
+			// 	}
 
-				try {
-					resolvedPluginConfig = resolvePluginConfig(
-						pluginConfig,
-						viteUserConfig,
-					);
+			// 	try {
+			// 		resolvedPluginConfig = resolvePluginConfig(
+			// 			pluginConfig,
+			// 			viteUserConfig,
+			// 		);
 
-					await miniflare.setOptions(
-						getDevMiniflareOptions(resolvedPluginConfig, viteDevServer),
-					);
+			// 		await miniflare.setOptions(
+			// 			getDevMiniflareOptions(resolvedPluginConfig, viteDevServer),
+			// 		);
 
-					await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
+			// 		await initRunners(resolvedPluginConfig, viteDevServer, miniflare);
 
-					error = undefined;
-					viteDevServer.environments.client.hot.send({ type: 'full-reload' });
-				} catch (err) {
-					error = err;
-					viteDevServer.environments.client.hot.send({ type: 'full-reload' });
-				}
-			});
+			// 		error = undefined;
+			// 		viteDevServer.environments.client.hot.send({ type: 'full-reload' });
+			// 	} catch (err) {
+			// 		error = err;
+			// 		viteDevServer.environments.client.hot.send({ type: 'full-reload' });
+			// 	}
+			// });
 
 			const middleware = createMiddleware(async ({ request }) => {
 				const routerWorker = await getRouterWorker(miniflare);

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -204,7 +204,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 		},
 		async buildEnd() {
 			if (miniflare) {
-				await miniflare?.dispose();
+				await miniflare.dispose();
 				miniflare = undefined;
 			}
 		},

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -126,7 +126,7 @@ export function resolvePluginConfig(
 	const root = userConfig.root ? path.resolve(userConfig.root) : process.cwd();
 
 	const configPath = pluginConfig.configPath
-		? path.join(root, pluginConfig.configPath)
+		? path.resolve(root, pluginConfig.configPath)
 		: findWranglerConfig(root);
 
 	assert(
@@ -152,7 +152,7 @@ export function resolvePluginConfig(
 
 	for (const auxiliaryWorker of pluginConfig.auxiliaryWorkers ?? []) {
 		const configResult = getConfigResult(
-			path.join(root, auxiliaryWorker.configPath),
+			path.resolve(root, auxiliaryWorker.configPath),
 			configPaths,
 		);
 

--- a/playground/react-spa/wrangler.toml
+++ b/playground/react-spa/wrangler.toml
@@ -1,1 +1,1 @@
-assets = { directory = "dummy-directory", not_found_handling = "single-page-application" }
+assets = { not_found_handling = "single-page-application" }

--- a/playground/spa-with-api/wrangler.toml
+++ b/playground/spa-with-api/wrangler.toml
@@ -1,4 +1,4 @@
 name = "api"
 main = "./api/index.ts"
 compatibility_date = "2024-09-09"
-assets = { directory = "dummy-directory", not_found_handling = "single-page-application", binding = "ASSETS" }
+assets = { not_found_handling = "single-page-application", binding = "ASSETS" }

--- a/playground/static-mpa/wrangler.toml
+++ b/playground/static-mpa/wrangler.toml
@@ -1,1 +1,1 @@
-assets = { directory = "dummy-directory", html_handling = "auto-trailing-slash", not_found_handling = "404-page" }
+assets = { html_handling = "auto-trailing-slash", not_found_handling = "404-page" }


### PR DESCRIPTION
resolves #54

This simplifies things quite a bit. I'm also cleaning up the Miniflare instance on restarts now.

Note that the removal of the `assets.directory` field in some of playgrounds isn't related to this PR (meant to do it in the last one).