### PR TITLE
fix: ensure that the unenv package is available at runtime

### DIFF
--- a/packages/vite-plugin-cloudflare/package.json
+++ b/packages/vite-plugin-cloudflare/package.json
@@ -36,7 +36,8 @@
 	},
 	"dependencies": {
 		"@hattip/adapter-node": "^0.0.49",
-		"miniflare": "^3.20241205.0"
+		"miniflare": "^3.20241205.0",
+		"unenv": "catalog:default"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-shared": "^0.7.0",
@@ -46,7 +47,6 @@
 		"magic-string": "^0.30.12",
 		"tsup": "^8.3.0",
 		"typescript": "catalog:default",
-		"unenv": "catalog:default",
 		"vite": "catalog:default",
 		"wrangler": "catalog:default"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       miniflare:
         specifier: ^3.20241205.0
         version: 3.20241205.0
+      unenv:
+        specifier: catalog:default
+        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
     devDependencies:
       '@cloudflare/workers-shared':
         specifier: ^0.7.0
@@ -93,9 +96,6 @@ importers:
       typescript:
         specifier: catalog:default
         version: 5.7.2
-      unenv:
-        specifier: catalog:default
-        version: unenv-nightly@2.0.0-20241204-140205-a5d5190
       vite:
         specifier: catalog:default
         version: 6.0.3(@types/node@22.10.1)


### PR DESCRIPTION
By moving the unenv dep into the dependencies rather than devDependencies, it is installed at runtime for the user of the plugin.

Otherwise we get errors like:

```
 Internal server error: Cannot find module 'unenv/runtime/node/process/$cloudflare' imported from '~/src/index.ts'
```