### PR TITLE
Set persistState to false in playgrounds

### DIFF
--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -9,12 +9,12 @@ export type PersistState = boolean | { path: string };
 
 interface PluginWorkerConfig {
 	configPath: string;
-	persistState?: PersistState;
 	viteEnvironment?: { name?: string };
 }
 
 export interface PluginConfig extends Partial<PluginWorkerConfig> {
 	auxiliaryWorkers?: PluginWorkerConfig[];
+	persistState?: PersistState;
 }
 
 type Defined<T> = Exclude<T, undefined>;

--- a/playground/durable-objects/vite.config.ts
+++ b/playground/durable-objects/vite.config.ts
@@ -2,5 +2,5 @@ import { cloudflare } from '@flarelabs-net/vite-plugin-cloudflare';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [cloudflare()],
+	plugins: [cloudflare({ persistState: false })],
 });

--- a/playground/external-durable-objects/vite.config.ts
+++ b/playground/external-durable-objects/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		cloudflare({
 			configPath: './worker-a/wrangler.toml',
 			auxiliaryWorkers: [{ configPath: './worker-b/wrangler.toml' }],
+			persistState: false,
 		}),
 	],
 });

--- a/playground/hot-channel/vite.config.ts
+++ b/playground/hot-channel/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [
-		cloudflare(),
+		cloudflare({ persistState: false }),
 		{
 			name: 'test-plugin',
 			configureServer(viteDevServer) {

--- a/playground/module-resolution/vite.config.no-prebundling.ts
+++ b/playground/module-resolution/vite.config.no-prebundling.ts
@@ -20,5 +20,7 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [cloudflare({ viteEnvironment: { name: 'worker' } })],
+	plugins: [
+		cloudflare({ viteEnvironment: { name: 'worker' }, persistState: false }),
+	],
 });

--- a/playground/module-resolution/vite.config.ts
+++ b/playground/module-resolution/vite.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
 			'@alias/test': resolve(__dirname, './src/aliasing.ts'),
 		},
 	},
-	plugins: [cloudflare()],
+	plugins: [cloudflare({ persistState: false })],
 });

--- a/playground/multi-worker/vite.config.ts
+++ b/playground/multi-worker/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		cloudflare({
 			configPath: './worker-a/wrangler.toml',
 			auxiliaryWorkers: [{ configPath: './worker-b/wrangler.toml' }],
+			persistState: false,
 		}),
 	],
 });

--- a/playground/node-compat/vite.config.worker-basic.ts
+++ b/playground/node-compat/vite.config.worker-basic.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-basic',
 	},
-	plugins: [cloudflare({ configPath: './worker-basic/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-basic/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/node-compat/vite.config.worker-cross-env.ts
+++ b/playground/node-compat/vite.config.worker-cross-env.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-cross-env',
 	},
-	plugins: [cloudflare({ configPath: './worker-cross-env/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-cross-env/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/node-compat/vite.config.worker-crypto.ts
+++ b/playground/node-compat/vite.config.worker-crypto.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-crypto',
 	},
-	plugins: [cloudflare({ configPath: './worker-crypto/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-crypto/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/node-compat/vite.config.worker-postgres.ts
+++ b/playground/node-compat/vite.config.worker-postgres.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-postgres',
 	},
-	plugins: [cloudflare({ configPath: './worker-postgres/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-postgres/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/node-compat/vite.config.worker-process.ts
+++ b/playground/node-compat/vite.config.worker-process.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-process',
 	},
-	plugins: [cloudflare({ configPath: './worker-process/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-process/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/node-compat/vite.config.worker-random.ts
+++ b/playground/node-compat/vite.config.worker-random.ts
@@ -5,5 +5,10 @@ export default defineConfig({
 	build: {
 		outDir: 'dist/worker-random',
 	},
-	plugins: [cloudflare({ configPath: './worker-random/wrangler.toml' })],
+	plugins: [
+		cloudflare({
+			configPath: './worker-random/wrangler.toml',
+			persistState: false,
+		}),
+	],
 });

--- a/playground/react-spa/vite.config.ts
+++ b/playground/react-spa/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [react(), cloudflare()],
+	plugins: [react(), cloudflare({ persistState: false })],
 });

--- a/playground/spa-with-api/vite.config.ts
+++ b/playground/spa-with-api/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [react(), cloudflare()],
+	plugins: [react(), cloudflare({ persistState: false })],
 });

--- a/playground/static-mpa/vite.config.ts
+++ b/playground/static-mpa/vite.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
 			},
 		},
 	},
-	plugins: [cloudflare()],
+	plugins: [cloudflare({ persistState: false })],
 });

--- a/playground/worker/vite.config.ts
+++ b/playground/worker/vite.config.ts
@@ -2,5 +2,5 @@ import { cloudflare } from '@flarelabs-net/vite-plugin-cloudflare';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [cloudflare()],
+	plugins: [cloudflare({ persistState: false })],
 });


### PR DESCRIPTION
I noticed that if the tests reran then stateful tests (e.g. durable objects) would fail as the state was being preserved. This sets `persistState: false` in all playgrounds and removes an error in the plugin TypeScript that meant `persistState` was a config option in auxiliary workers.