### PR TITLE
set `keepProcessEnv` to `false` and re-enable `react` module-resolution test

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -179,7 +179,6 @@ export function createCloudflareEnvironmentOptions(
 				],
 			},
 		},
-		keepProcessEnv: false,
 	};
 }
 

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -179,7 +179,7 @@ export function createCloudflareEnvironmentOptions(
 				],
 			},
 		},
-		keepProcessEnv: true,
+		keepProcessEnv: false,
 	};
 }
 

--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -179,6 +179,7 @@ export function createCloudflareEnvironmentOptions(
 				],
 			},
 		},
+		keepProcessEnv: false,
 	};
 }
 

--- a/playground/module-resolution/__tests__/module-resolution.spec.ts
+++ b/playground/module-resolution/__tests__/module-resolution.spec.ts
@@ -76,9 +76,7 @@ describe('module resolution', async () => {
 	 *  special meaning to us.
 	 */
 	describe('third party packages resolutions', () => {
-		// TODO: we skip this test on build because a `ReferenceError: process is not defined` is thrown
-		//       (https://github.com/flarelabs-net/vite-plugin-cloudflare/issues/82)
-		test.skipIf(isBuild)('react', async () => {
+		test('react', async () => {
 			const result = await getJsonResponse('/third-party/react');
 			expect(result).toEqual({
 				'(react) reactVersionsMatch': true,


### PR DESCRIPTION
resolves #82

___

As discussed in #94 

As per [our docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs/process/#processenv):
![Screenshot 2024-12-10 at 17 01 00](https://github.com/user-attachments/assets/7a6ee310-2948-4000-86b5-f222a59642f6)

in workers `process.env` is an empty object, so I think it's actually ok to just use `keepProcessEnv: false` since [Vite replaces `process.env`s with empty objects](https://github.com/vitejs/vite/blob/258cdd637d1ee80a3c4571685135e89fe283f3a6/packages/vite/src/node/plugins/define.ts#L23-L30), so I think that there is actually little to no difference between having `keepProcessEnv` set to `true` or `false` for us

Setting if to `false` has the benefit that Vite replaces `process.env.NODE_ENV` when `keepProcessEnv` is `false` ([discord message](
https://discord.com/channels/804011606160703521/1314204727621193788/1314404199747813446)) fixing the issue we were encountering with the `react` import

`keepProcessEnv: true` could be needed if the workerd `process.env` implementation were to change at some point, but right now `keepProcessEnv: false` might be the most appropriate configuration 