### PR TITLE
remove json call in remix module-resolution test

### DIFF
--- a/playground/module-resolution/__tests__/module-resolution.spec.ts
+++ b/playground/module-resolution/__tests__/module-resolution.spec.ts
@@ -87,16 +87,11 @@ describe('module resolution', async () => {
 			});
 		});
 
-		// Note: this test is skipped during build because the remix import does not work in preview
-		//       because there seem to be an I/O operation being performed at the top level of the
-		//       generated remix bundled module, this is a legitimate issue and a workerd known quirk/bug
-		//       (https://github.com/flarelabs-net/vite-plugin-cloudflare/issues/83)
-		test.skipIf(isBuild)('@remix-run/cloudflare', async () => {
+		test('@remix-run/cloudflare', async () => {
 			const result = await getJsonResponse('/third-party/remix');
 			expect(result).toEqual({
 				'(remix) remixRunCloudflareCookieName':
 					'my-remix-run-cloudflare-cookie',
-				'(remix) typeof cloudflare json({})': 'object',
 			});
 		});
 

--- a/playground/module-resolution/src/third-party/remix.ts
+++ b/playground/module-resolution/src/third-party/remix.ts
@@ -1,7 +1,6 @@
-import { createCookie, json } from '@remix-run/cloudflare';
+import { createCookie } from '@remix-run/cloudflare';
 
 export default {
-	'(remix) typeof cloudflare json({})': typeof json({}),
 	'(remix) remixRunCloudflareCookieName': createCookie(
 		'my-remix-run-cloudflare-cookie',
 	).name,


### PR DESCRIPTION
resolves #83 

___

This is a simple resolution for #83

I am simply removing the top-level call to the `json` utility so that the remix module resolution test can work in both dev and preview.

I personally don't think we should keep the test around with the comment just for documentation purposes, we should document this behavior properly (#108) and if we wanted some playground examples for this we could add them as part of #108 (and they should clearly/purposely reproduce this and not, as the remix case, reproduce it just by coincidence)