### PR TITLE
Support Workflows

### DIFF
--- a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
+++ b/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts
@@ -114,6 +114,7 @@ const cloudflareBuiltInModules = [
 	'cloudflare:email',
 	'cloudflare:sockets',
 	'cloudflare:workers',
+	'cloudflare:workflows',
 ];
 
 export function createCloudflareEnvironmentOptions(

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -150,6 +150,8 @@ function getWorkerToWorkflowClassNamesMap(
 			}
 		}
 	}
+
+	return workerToWorkflowClassNamesMap;
 }
 
 // We want module names to be their absolute path without the leading slash

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -30,6 +30,7 @@ type PersistOptions = Pick<
 	| 'durableObjectsPersist'
 	| 'kvPersist'
 	| 'r2Persist'
+	| 'workflowsPersist'
 >;
 
 function getPersistence(
@@ -53,6 +54,7 @@ function getPersistence(
 		durableObjectsPersist: path.join(persistPath, 'do'),
 		kvPersist: path.join(persistPath, 'kv'),
 		r2Persist: path.join(persistPath, 'r2'),
+		workflowsPersist: path.join(persistPath, 'workflows'),
 	};
 }
 

--- a/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
+++ b/packages/vite-plugin-cloudflare/src/runner-worker/index.ts
@@ -22,14 +22,12 @@ interface DurableObjectConstructor<T = unknown> {
 
 interface WorkflowEntrypointConstructor<T = unknown> {
 	new (
-		// No constructor in `WorkerEntrypoint` type
+		// Constructor type to be added in https://github.com/cloudflare/workerd/pull/3239
 		// ...args: ConstructorParameters<typeof WorkflowEntrypoint<T>>
 		ctx: ExecutionContext,
 		env: T,
 	): WorkflowEntrypoint<T>;
 }
-
-type T = ConstructorParameters<typeof WorkerEntrypoint>;
 
 const WORKER_ENTRYPOINT_KEYS = [
 	'fetch',

--- a/playground/external-durable-objects/worker-b/index.ts
+++ b/playground/external-durable-objects/worker-b/index.ts
@@ -1,9 +1,5 @@
 import { DurableObject } from 'cloudflare:workers';
 
-interface Env {
-	COUNTERS: DurableObjectNamespace<Counter>;
-}
-
 export class Counter extends DurableObject {
 	async getCounterValue() {
 		let value = ((await this.ctx.storage.get('value')) as number) || 0;
@@ -19,33 +15,3 @@ export class Counter extends DurableObject {
 		return value;
 	}
 }
-
-export default {
-	async fetch(request, env) {
-		let url = new URL(request.url);
-		let name = url.searchParams.get('name');
-
-		if (!name) {
-			throw new Error(
-				'Select a Durable Object to contact by using the `name` URL query string parameter, for example, ?name=A',
-			);
-		}
-
-		const id = env.COUNTERS.idFromName(name);
-		const stub = env.COUNTERS.get(id);
-		let count = null;
-
-		switch (url.pathname) {
-			case '/increment':
-				count = await stub.increment();
-				break;
-			case '/':
-				count = await stub.getCounterValue();
-				break;
-			default:
-				throw new Error('Unhandled route');
-		}
-
-		return Response.json({ name, count });
-	},
-} satisfies ExportedHandler<Env>;

--- a/playground/external-durable-objects/worker-b/wrangler.toml
+++ b/playground/external-durable-objects/worker-b/wrangler.toml
@@ -1,10 +1,3 @@
 name = "worker-b"
 main = "./index.ts"
 compatibility_date = "2024-09-09"
-
-[durable_objects]
-bindings = [{ name = "COUNTERS", class_name = "Counter" }]
-
-[[migrations]]
-tag = "v1"
-new_classes = ["Counter"]

--- a/playground/external-workflows/__tests__/workflows.spec.ts
+++ b/playground/external-workflows/__tests__/workflows.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test, vi } from 'vitest';
+import { getJsonResponse } from '../../__test-utils__';
+
+test('creates a Workflow with an ID', async () => {
+	const instanceId = 'test-id';
+
+	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
+		id: instanceId,
+		status: {
+			status: 'running',
+			output: [],
+		},
+	});
+
+	await vi.waitFor(
+		async () => {
+			expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
+				status: 'running',
+				output: [{ output: 'First step result' }],
+			});
+		},
+		{ timeout: 5000 },
+	);
+
+	await vi.waitFor(
+		async () => {
+			expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
+				status: 'complete',
+				output: [
+					{ output: 'First step result' },
+					{ output: 'Second step result' },
+				],
+			});
+		},
+		{ timeout: 5000 },
+	);
+});

--- a/playground/external-workflows/package.json
+++ b/playground/external-workflows/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@playground/workflows",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:default",
+		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
+		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
+		"vite": "catalog:default",
+		"wrangler": "catalog:default"
+	}
+}

--- a/playground/external-workflows/tsconfig.json
+++ b/playground/external-workflows/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/playground/external-workflows/tsconfig.node.json
+++ b/playground/external-workflows/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@vite-plugin-cloudflare/typescript-config/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/playground/external-workflows/tsconfig.worker.json
+++ b/playground/external-workflows/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@vite-plugin-cloudflare/typescript-config/worker.json"],
+	"include": ["worker-a", "worker-b"]
+}

--- a/playground/external-workflows/vite.config.ts
+++ b/playground/external-workflows/vite.config.ts
@@ -1,0 +1,12 @@
+import { cloudflare } from '@flarelabs-net/vite-plugin-cloudflare';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			configPath: './worker-a/wrangler.toml',
+			auxiliaryWorkers: [{ configPath: './worker-b/wrangler.toml' }],
+			persistState: false,
+		}),
+	],
+});

--- a/playground/external-workflows/worker-a/index.ts
+++ b/playground/external-workflows/worker-a/index.ts
@@ -1,0 +1,37 @@
+interface Env {
+	MY_WORKFLOW: Workflow;
+}
+
+export default {
+	async fetch(request, env) {
+		const url = new URL(request.url);
+		const id = url.searchParams.get('id');
+
+		if (url.pathname === '/create') {
+			const instance = await env.MY_WORKFLOW.create(
+				id === null ? undefined : { id },
+			);
+
+			return Response.json({
+				id: instance.id,
+				status: await instance.status(),
+			});
+		}
+
+		if (url.pathname === '/get') {
+			if (id === null) {
+				return new Response(
+					'Please provide an id (`/get?id=unique-instance-id`)',
+				);
+			}
+
+			const instance = await env.MY_WORKFLOW.get(id);
+
+			return Response.json(await instance.status());
+		}
+
+		return new Response(
+			'Create a new Workflow instance (`/create` or `/create?id=unique-instance-id`) or inspect an existing instance (`/get?id=unique-instance-id`).',
+		);
+	},
+} satisfies ExportedHandler<Env>;

--- a/playground/external-workflows/worker-a/wrangler.toml
+++ b/playground/external-workflows/worker-a/wrangler.toml
@@ -1,0 +1,9 @@
+name = "worker-a"
+main = "./index.ts"
+compatibility_date = "2024-09-09"
+
+[[workflows]]
+name = "workflow"
+binding = "MY_WORKFLOW"
+script_name = "worker-b"
+class_name = "MyWorkflow"

--- a/playground/external-workflows/worker-b/index.ts
+++ b/playground/external-workflows/worker-b/index.ts
@@ -1,0 +1,20 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+
+export class MyWorkflow extends WorkflowEntrypoint {
+	override async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+		await step.do('first step', async () => {
+			return {
+				output: 'First step result',
+			};
+		});
+
+		await step.sleep('sleep', '1 second');
+
+		await step.do('second step', async () => {
+			return {
+				output: 'Second step result',
+			};
+		});
+	}
+}

--- a/playground/external-workflows/worker-b/wrangler.toml
+++ b/playground/external-workflows/worker-b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "worker-b"
+main = "./index.ts"
+compatibility_date = "2024-09-09"

--- a/playground/workflows/__tests__/workflows.spec.ts
+++ b/playground/workflows/__tests__/workflows.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest';
+import { getJsonResponse } from '../../__test-utils__';
+
+test('creates a Workflow with an ID', async () => {
+	const instanceId = 'test-id';
+
+	expect(await getJsonResponse(`/create?instance-id=${instanceId}`)).toEqual({
+		status: 'running',
+		output: [],
+	});
+
+	await vi.waitFor(
+		async () => {
+			expect(await getJsonResponse(`/?instance-id=${instanceId}`)).toEqual({
+				status: 'running',
+				output: [{ output: 'First step result' }],
+			});
+		},
+		{ timeout: 5000 },
+	);
+
+	await vi.waitFor(
+		async () => {
+			expect(await getJsonResponse(`/?instance-id=${instanceId}`)).toEqual({
+				status: 'complete',
+				output: [
+					{ output: 'First step result' },
+					{ output: 'Second step result' },
+				],
+			});
+		},
+		{ timeout: 5000 },
+	);
+});

--- a/playground/workflows/__tests__/workflows.spec.ts
+++ b/playground/workflows/__tests__/workflows.spec.ts
@@ -4,14 +4,17 @@ import { getJsonResponse } from '../../__test-utils__';
 test('creates a Workflow with an ID', async () => {
 	const instanceId = 'test-id';
 
-	expect(await getJsonResponse(`/create?instance-id=${instanceId}`)).toEqual({
-		status: 'running',
-		output: [],
+	expect(await getJsonResponse(`/create?id=${instanceId}`)).toEqual({
+		id: instanceId,
+		status: {
+			status: 'running',
+			output: [],
+		},
 	});
 
 	await vi.waitFor(
 		async () => {
-			expect(await getJsonResponse(`/?instance-id=${instanceId}`)).toEqual({
+			expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 				status: 'running',
 				output: [{ output: 'First step result' }],
 			});
@@ -21,7 +24,7 @@ test('creates a Workflow with an ID', async () => {
 
 	await vi.waitFor(
 		async () => {
-			expect(await getJsonResponse(`/?instance-id=${instanceId}`)).toEqual({
+			expect(await getJsonResponse(`/get?id=${instanceId}`)).toEqual({
 				status: 'complete',
 				output: [
 					{ output: 'First step result' },

--- a/playground/workflows/package.json
+++ b/playground/workflows/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@playground/workflows",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build --app",
+		"check:types": "tsc --build",
+		"dev": "vite dev",
+		"preview": "vite preview"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "catalog:default",
+		"@flarelabs-net/vite-plugin-cloudflare": "workspace:*",
+		"@vite-plugin-cloudflare/typescript-config": "workspace:*",
+		"typescript": "catalog:default",
+		"vite": "catalog:default",
+		"wrangler": "catalog:default"
+	}
+}

--- a/playground/workflows/src/index.ts
+++ b/playground/workflows/src/index.ts
@@ -1,5 +1,26 @@
+import { WorkflowEntrypoint } from 'cloudflare:workers';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+
+interface Env {
+	MY_WORKFLOW: Workflow;
+}
+
+interface Params {}
+
+export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
+	override async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+		let state = step.do('my first step', async () => {});
+
+		step.do('my second step', async () => {});
+	}
+}
+
 export default {
-	async fetch() {
-		return new Response('Hello World!');
+	async fetch(request, env) {
+		const instance = await env.MY_WORKFLOW.create();
+
+		return Response.json({
+			id: instance.id,
+		});
 	},
-} satisfies ExportedHandler;
+} satisfies ExportedHandler<Env>;

--- a/playground/workflows/src/index.ts
+++ b/playground/workflows/src/index.ts
@@ -26,20 +26,35 @@ export class MyWorkflow extends WorkflowEntrypoint<Env> {
 export default {
 	async fetch(request, env) {
 		const url = new URL(request.url);
-		const id = url.searchParams.get('instance-id');
-
-		if (!id) {
-			return new Response(null, { status: 404 });
-		}
+		const id = url.searchParams.get('id');
 
 		if (url.pathname === '/create') {
-			const instance = await env.MY_WORKFLOW.create({ id });
+			let instance: WorkflowInstance;
 
-			return Response.json(await instance.status());
+			if (id === null) {
+				instance = await env.MY_WORKFLOW.create();
+			} else {
+				instance = await env.MY_WORKFLOW.create({ id });
+			}
+
+			return Response.json({
+				id: instance.id,
+				status: await instance.status(),
+			});
+		} else if (url.pathname === '/get') {
+			if (id === null) {
+				return new Response(
+					'Please provide an id (`/get?id=unique-instance-id`)',
+				);
+			} else {
+				const instance = await env.MY_WORKFLOW.get(id);
+
+				return Response.json(await instance.status());
+			}
+		} else {
+			return new Response(
+				'Create a new Workflow instance (`/create` or `/create?id=unique-instance-id`) or inspect an existing instance (`/get?id=unique-instance-id`).',
+			);
 		}
-
-		const instance = await env.MY_WORKFLOW.get(id);
-
-		return Response.json(await instance.status());
 	},
 } satisfies ExportedHandler<Env>;

--- a/playground/workflows/src/index.ts
+++ b/playground/workflows/src/index.ts
@@ -29,32 +29,30 @@ export default {
 		const id = url.searchParams.get('id');
 
 		if (url.pathname === '/create') {
-			let instance: WorkflowInstance;
-
-			if (id === null) {
-				instance = await env.MY_WORKFLOW.create();
-			} else {
-				instance = await env.MY_WORKFLOW.create({ id });
-			}
+			const instance = await env.MY_WORKFLOW.create(
+				id === null ? undefined : { id },
+			);
 
 			return Response.json({
 				id: instance.id,
 				status: await instance.status(),
 			});
-		} else if (url.pathname === '/get') {
+		}
+
+		if (url.pathname === '/get') {
 			if (id === null) {
 				return new Response(
 					'Please provide an id (`/get?id=unique-instance-id`)',
 				);
-			} else {
-				const instance = await env.MY_WORKFLOW.get(id);
-
-				return Response.json(await instance.status());
 			}
-		} else {
-			return new Response(
-				'Create a new Workflow instance (`/create` or `/create?id=unique-instance-id`) or inspect an existing instance (`/get?id=unique-instance-id`).',
-			);
+
+			const instance = await env.MY_WORKFLOW.get(id);
+
+			return Response.json(await instance.status());
 		}
+
+		return new Response(
+			'Create a new Workflow instance (`/create` or `/create?id=unique-instance-id`) or inspect an existing instance (`/get?id=unique-instance-id`).',
+		);
 	},
 } satisfies ExportedHandler<Env>;

--- a/playground/workflows/src/index.ts
+++ b/playground/workflows/src/index.ts
@@ -5,22 +5,41 @@ interface Env {
 	MY_WORKFLOW: Workflow;
 }
 
-interface Params {}
-
-export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
+export class MyWorkflow extends WorkflowEntrypoint<Env> {
 	override async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
-		let state = step.do('my first step', async () => {});
+		await step.do('first step', async () => {
+			return {
+				output: 'First step result',
+			};
+		});
 
-		step.do('my second step', async () => {});
+		await step.sleep('sleep', '1 second');
+
+		await step.do('second step', async () => {
+			return {
+				output: 'Second step result',
+			};
+		});
 	}
 }
 
 export default {
 	async fetch(request, env) {
-		const instance = await env.MY_WORKFLOW.create();
+		const url = new URL(request.url);
+		const id = url.searchParams.get('instance-id');
 
-		return Response.json({
-			id: instance.id,
-		});
+		if (!id) {
+			return new Response(null, { status: 404 });
+		}
+
+		if (url.pathname === '/create') {
+			const instance = await env.MY_WORKFLOW.create({ id });
+
+			return Response.json(await instance.status());
+		}
+
+		const instance = await env.MY_WORKFLOW.get(id);
+
+		return Response.json(await instance.status());
 	},
 } satisfies ExportedHandler<Env>;

--- a/playground/workflows/src/index.ts
+++ b/playground/workflows/src/index.ts
@@ -1,0 +1,5 @@
+export default {
+	async fetch() {
+		return new Response('Hello World!');
+	},
+} satisfies ExportedHandler;

--- a/playground/workflows/tsconfig.json
+++ b/playground/workflows/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"files": [],
+	"references": [
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.worker.json" }
+	]
+}

--- a/playground/workflows/tsconfig.node.json
+++ b/playground/workflows/tsconfig.node.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@vite-plugin-cloudflare/typescript-config/base.json"],
+	"include": ["vite.config.ts", "__tests__"]
+}

--- a/playground/workflows/tsconfig.worker.json
+++ b/playground/workflows/tsconfig.worker.json
@@ -1,0 +1,4 @@
+{
+	"extends": ["@vite-plugin-cloudflare/typescript-config/worker.json"],
+	"include": ["src"]
+}

--- a/playground/workflows/vite.config.ts
+++ b/playground/workflows/vite.config.ts
@@ -1,0 +1,6 @@
+import { cloudflare } from '@flarelabs-net/vite-plugin-cloudflare';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [cloudflare({ persistState: false })],
+});

--- a/playground/workflows/wrangler.toml
+++ b/playground/workflows/wrangler.toml
@@ -1,0 +1,8 @@
+name = "worker"
+main = "./src/index.ts"
+compatibility_date = "2024-09-09"
+
+[[workflows]]
+name = "workflow"
+binding = "MY_WORKFLOW"
+class_name = "MyWorkflow"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,27 @@ importers:
         specifier: catalog:default
         version: 3.94.0(@cloudflare/workers-types@4.20241205.0)
 
+  playground/workflows:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: catalog:default
+        version: 4.20241205.0
+      '@flarelabs-net/vite-plugin-cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-cloudflare
+      '@vite-plugin-cloudflare/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.7.2
+      vite:
+        specifier: catalog:default
+        version: 6.0.3(@types/node@22.10.1)
+      wrangler:
+        specifier: catalog:default
+        version: 3.94.0(@cloudflare/workers-types@4.20241205.0)
+
 packages:
 
   '@ampproject/remapping@2.3.0':
@@ -2305,10 +2326,6 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.4.47:
-    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3060,7 +3077,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   '@babel/parser@7.25.8':
     dependencies:
@@ -4548,12 +4565,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.49
 
-  postcss@8.4.47:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
-      source-map-js: 1.2.1
-
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.7
@@ -4930,7 +4941,7 @@ snapshots:
     dependencies:
       browserslist: 4.24.0
       escalade: 3.2.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
 
   url-join@5.0.0: {}
 
@@ -4958,7 +4969,7 @@ snapshots:
   vite@5.4.10(@types/node@22.10.1):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.47
+      postcss: 8.4.49
       rollup: 4.24.0
     optionalDependencies:
       '@types/node': 22.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,27 @@ importers:
         specifier: catalog:default
         version: 3.94.0(@cloudflare/workers-types@4.20241205.0)
 
+  playground/external-workflows:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: catalog:default
+        version: 4.20241205.0
+      '@flarelabs-net/vite-plugin-cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-cloudflare
+      '@vite-plugin-cloudflare/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: catalog:default
+        version: 5.7.2
+      vite:
+        specifier: catalog:default
+        version: 6.0.3(@types/node@22.10.1)
+      wrangler:
+        specifier: catalog:default
+        version: 3.94.0(@cloudflare/workers-types@4.20241205.0)
+
   playground/hot-channel:
     devDependencies:
       '@cloudflare/workers-types':


### PR DESCRIPTION
resolves #65

Few things to note:
- I initially created a more complex implementation that held onto class instances across requests (similar to the Durable Objects implementation). This turned out to not be necessary because the Workflow `create` method is a one time trigger and the instance ID is unique per Workflow (https://developers.cloudflare.com/workflows/build/rules-of-workflows/#instance-ids-are-unique). I therefore simplified the implementation.
- Changes in the user code won't stop an existing Workflow instance from continuing to execute. This behaviour differs from Wrangler, which restarts Miniflare on any code changes. I have asked the Workflows team for clarification on what happens in production when a new version of the Workflow is deployed while an existing Workflow instance is running.