### PR TITLE
Re-enable Node.js compatibility

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -109,16 +109,7 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 			}
 
 			const aliased = resolveNodeAliases(source, workerConfig);
-
-			if (!aliased) {
-				return;
-			}
-
-			if (aliased.external) {
-				return aliased.id;
-			} else {
-				return await this.resolve(aliased.id);
-			}
+			return aliased && (await this.resolve(aliased));
 		},
 		async transform(code, id) {
 			if (resolvedPluginConfig.type === 'assets-only') {

--- a/packages/vite-plugin-cloudflare/src/miniflare-options.ts
+++ b/packages/vite-plugin-cloudflare/src/miniflare-options.ts
@@ -301,19 +301,6 @@ export function getDevMiniflareOptions(
 										return new MiniflareResponse(JSON.stringify({ result }));
 									}
 
-									// Sometimes Vite fails to resolve built-ins and converts them to "url-friendly" ids
-									// that start with `/@id/...`.
-									// This was necessary for `nodejs_compat` to work but has been removed as it had unintended side-effects.
-									// An alternative will be implemented in #63
-									// if (moduleId.startsWith('/@id/')) {
-									// 	const result = {
-									// 		externalize: moduleId.slice('/@id/'.length),
-									// 		type: 'builtin',
-									// 	} satisfies vite.FetchResult;
-
-									// 	return new MiniflareResponse(JSON.stringify({ result }));
-									// }
-
 									const devEnvironment = viteDevServer.environments[
 										environmentName
 									] as CloudflareDevEnvironment;

--- a/playground/node-compat/__tests__/worker-basic/basic.spec.ts
+++ b/playground/node-compat/__tests__/worker-basic/basic.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 import { getTextResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('basic nodejs properties', async () => {
+test('basic nodejs properties', async () => {
 	const result = await getTextResponse();
 	expect(result).toBe(`"OK!"`);
 });

--- a/playground/node-compat/__tests__/worker-cross-env/cross-env.spec.ts
+++ b/playground/node-compat/__tests__/worker-cross-env/cross-env.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 import { getTextResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('import unenv aliased 3rd party packages (e.g. cross-env)', async () => {
+test('import unenv aliased 3rd party packages (e.g. cross-env)', async () => {
 	const result = await getTextResponse();
 	expect(result).toBe(`"OK!"`);
 });

--- a/playground/node-compat/__tests__/worker-crypto/crypto.spec.ts
+++ b/playground/node-compat/__tests__/worker-crypto/crypto.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 import { getTextResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('crypto.X509Certificate is implemented', async () => {
+test('crypto.X509Certificate is implemented', async () => {
 	const result = await getTextResponse();
 	expect(result).toMatchInlineSnapshot(`
 		""OK!": -----BEGIN CERTIFICATE-----

--- a/playground/node-compat/__tests__/worker-postgres/postgres.spec.ts
+++ b/playground/node-compat/__tests__/worker-postgres/postgres.spec.ts
@@ -1,18 +1,17 @@
 import { expect, test } from 'vitest';
 import { getJsonResponse, getTextResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('should be able to create a pg Client', async () => {
+test('should be able to create a pg Client', async () => {
 	const result = await getTextResponse();
 	expect(result).toMatchInlineSnapshot(`"hh-pgsql-public.ebi.ac.uk"`);
 });
 
 // Disabling actually querying the database in CI since we are getting this error:
 // > too many connections for role 'reader'
-// TODO: reintroduce test
-test
-	.runIf(!process.env.CI)
-	.skip('should be able to use pg library to send a query', async () => {
+test.runIf(!process.env.CI)(
+	'should be able to use pg library to send a query',
+	async () => {
 		const result = await getJsonResponse('/send-query');
 		expect(result!.id).toEqual('1');
-	});
+	},
+);

--- a/playground/node-compat/__tests__/worker-process/process.spec.ts
+++ b/playground/node-compat/__tests__/worker-process/process.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 import { getTextResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('should support process global', async () => {
+test('should support process global', async () => {
 	const result = await getTextResponse();
 	expect(result).toBe(`OK!`);
 });

--- a/playground/node-compat/__tests__/worker-random/random.spec.ts
+++ b/playground/node-compat/__tests__/worker-random/random.spec.ts
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 import { getJsonResponse } from '../../../__test-utils__';
 
-// TODO: reintroduce test in #63
-test.skip('should be able to call `getRandomValues()` bound to any object', async () => {
+test('should be able to call `getRandomValues()` bound to any object', async () => {
 	const result = await getJsonResponse();
 	expect(result).toEqual([
 		expect.any(String),


### PR DESCRIPTION
It turned out that the problems were arising because we were also creating virtual modules for Node.js aliases that were already actually expected to be external.

Fixes https://github.com/flarelabs-net/vite-plugin-cloudflare/issues/63

(I still think there is a potential bug in Vite, where you cannot have a virtual module that resolves to an external import, but that become moot by avoiding such cases here.)