### PR TITLE
feat: run writeDeployConfig in buildEnd

### DIFF
--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -100,8 +100,6 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 								),
 							);
 						}
-
-						writeDeployConfig(resolvedPluginConfig, resolvedViteConfig);
 					},
 				},
 			};
@@ -222,6 +220,8 @@ export function cloudflare(pluginConfig: PluginConfig = {}): vite.Plugin {
 			}
 		},
 		async buildEnd() {
+			writeDeployConfig(resolvedPluginConfig, resolvedViteConfig);
+
 			if (miniflare) {
 				await miniflare.dispose();
 				miniflare = undefined;


### PR DESCRIPTION
This allows for you to have a custom `builder.buildApp` and still get the necessary files written to disk to support the `preview` command.